### PR TITLE
Adapt to OpenSSL 1.1.0

### DIFF
--- a/t/10-selftest.t
+++ b/t/10-selftest.t
@@ -5,7 +5,7 @@ use strict;
 use Test;
 use Crypt::OpenSSL::DSA;
 
-BEGIN { plan tests => 30 }
+BEGIN { plan tests => 36 }
 
 my $message = "foo bar";
 
@@ -100,6 +100,22 @@ ok($dsa3->verify($message, $dsa_sig3), 1);
 ok($dsa4->verify($message, $dsa_sig3), 1);
 ok($dsa5->verify($message, $dsa_sig3), 1);
 ok($dsa6->verify($message, $dsa_sig3), 1);
+
+# Check setting private key before public key.
+# This is not suppored by OpenSSL-1.1.0.
+my $dsa7 = Crypt::OpenSSL::DSA->new();
+$dsa7->set_p($p);
+$dsa7->set_q($q);
+$dsa7->set_g($g);
+ok($dsa7->get_p,$p);
+ok($dsa7->get_q,$q);
+ok($dsa7->get_g,$g);
+$dsa7->set_priv_key($priv_key);
+ok($dsa7->get_priv_key,$priv_key);
+my $dsa_sig4 = $dsa7->sign($message);
+$dsa7->set_pub_key($pub_key);
+ok($dsa7->get_pub_key,$pub_key);
+ok($dsa7->verify($message, $dsa_sig4), 1);
 
 unlink("dsa.param.pem");
 unlink("dsa.priv.pem");

--- a/t/90-openssl-compat.t
+++ b/t/90-openssl-compat.t
@@ -74,7 +74,7 @@ sub openssl_verify {
     # FIXME: shutup openssl from spewing to STDOUT the "Verification
     # OK".  can we depend on reading "Verification OK" from the
     # open("-|", "openssl") open mode due to portability?
-    my $rv = system("openssl", "dgst", "-dss1", "-verify", $public_pem_file, "-signature", "$sig_temp", "$msg_temp");
+    my $rv = system("openssl", "dgst", "-sha1", "-verify", $public_pem_file, "-signature", "$sig_temp", "$msg_temp");
     return 0 if $rv;
     return 1;
 }


### PR DESCRIPTION
OpenSSL 1.1.0 hid structure internals and provided methods for reading
and writing them. This patch adapts to the changes so that it's
possible to build it against the new as well as as old OpenSSL
library.

Because the new OpenSSL does not support setting each prime number
separately, this patch fakes somes otherwise undefined values. This
looks ugly but this cannot be done better.

I recommend to add new Perl subroutines for setting the prime numbers in a
bulk as new OpenSSL does. These will be a strightforward binding with
less code and higher performance.

CPAN RT#118346