### PR TITLE
Allocate buffer for 2048 bit keys

### DIFF
--- a/DSA.xs
+++ b/DSA.xs
@@ -445,9 +445,11 @@ get_priv_key(dsa)
         const BIGNUM *priv_key;
         char *to;
         int len;
+        int bnlen;
     CODE:
         DSA_get0_key(dsa, NULL, &priv_key);
-        to = malloc(sizeof(char) * 128);
+        bnlen = BN_num_bytes(priv_key);
+        to = malloc(sizeof(char) * bnlen);
         len = BN_bn2bin(priv_key, to);
         RETVAL = newSVpvn(to, len);
         free(to);
@@ -643,9 +645,11 @@ get_r(dsa_sig)
         const BIGNUM *r;
         char *to;
         int len;
+        int bnlen;
     CODE:
         DSA_SIG_get0(dsa_sig, &r, NULL);
-        to = malloc(sizeof(char) * 128);
+        bnlen = BN_num_bytes(r);
+        to = malloc(sizeof(char) * bnlen);
         len = BN_bn2bin(r, to);
         RETVAL = newSVpvn(to, len);
         free(to);
@@ -659,9 +663,11 @@ get_s(dsa_sig)
         const BIGNUM *s;
         char *to;
         int len;
+        int bnlen;
     CODE:
         DSA_SIG_get0(dsa_sig, NULL, &s);
-        to = malloc(sizeof(char) * 128);
+        bnlen = BN_num_bytes(s);
+        to = malloc(sizeof(char) * bnlen);
         len = BN_bn2bin(s, to);
         RETVAL = newSVpvn(to, len);
         free(to);

--- a/DSA.xs
+++ b/DSA.xs
@@ -373,9 +373,11 @@ get_p(dsa)
         const BIGNUM *p;
         char *to;
         int len;
+        int bnlen;
     CODE:
         DSA_get0_pqg(dsa, &p, NULL, NULL);
-        to = malloc(sizeof(char) * 128);
+        bnlen = BN_num_bytes(p);
+        to = malloc(sizeof(char) * bnlen);
         len = BN_bn2bin(p, to);
         RETVAL = newSVpvn(to, len);
         free(to);
@@ -389,9 +391,11 @@ get_q(dsa)
         const BIGNUM *q;
         char *to;
         int len;
+        int bnlen;
     CODE:
         DSA_get0_pqg(dsa, NULL, &q, NULL);
-        to = malloc(sizeof(char) * 20);
+        bnlen = BN_num_bytes(q);
+        to = malloc(sizeof(char) * bnlen);
         len = BN_bn2bin(q, to);
         RETVAL = newSVpvn(to, len);
         free(to);
@@ -405,9 +409,11 @@ get_g(dsa)
         const BIGNUM *g;
         char *to;
         int len;
+        int bnlen;
     CODE:
         DSA_get0_pqg(dsa, NULL, NULL, &g);
-        to = malloc(sizeof(char) * 128);
+        bnlen = BN_num_bytes(g);
+        to = malloc(sizeof(char) * bnlen);
         len = BN_bn2bin(g, to);
         RETVAL = newSVpvn(to, len);
         free(to);
@@ -421,9 +427,11 @@ get_pub_key(dsa)
         const BIGNUM *pub_key;
         char *to;
         int len;
+        int bnlen;
     CODE:
         DSA_get0_key(dsa, &pub_key, NULL);
-        to = malloc(sizeof(char) * 128);
+        bnlen = BN_num_bytes(pub_key);
+        to = malloc(sizeof(char) * bnlen);
         len = BN_bn2bin(pub_key, to);
         RETVAL = newSVpvn(to, len);
         free(to);

--- a/lib/Crypt/OpenSSL/DSA.pm
+++ b/lib/Crypt/OpenSSL/DSA.pm
@@ -112,6 +112,38 @@ value of generate_parameters.
 Returns the maximum size of an ASN.1 encoded DSA signature for key
 dsa in bytes.
 
+ 512-bit keys = 48
+1024-bit keys = 48
+2024-bit keys = 72
+3072-bit keys = 72
+
+ASN.1 dsa signatures consist of:
+
+Sequence 1-byte (0x30)
+Length   1-byte
+Integer  1-byte (0x02)
+Length   1-byte (0x14) = 20
+r       20-bytes or 21-bytes
+Integer  1-byte (0x02)
+Length   1-byte (0x14) = 20
+s       20-bytes or 21-bytes
+
+30
+2C
+02
+14
+6C.70.50.7C.93.A8.B5.EC.1E.A1.5E.C5.73.AA.0F.EA.4D.BE.42.7A
+02
+14
+4E.AD.E6.BB.72.54.92.30.2B.03.AB.53.5D.3D.6E.88.B8.AA.D6.30
+
+Note that the above signature is 46 bytes long - the extra two bytes are used
+only when r and/or s are larger than or equal to 2^159.  The extra bytes are
+used to distinguish positive from negative values.
+
+All that to say if you are using get_sig_size() to determine the size of r + s
+depending on the size of the key you can subtract 8 bytes for the ASN.1 overhead.
+
 =item $sig = $dsa->sign( $message );
 
 Signs $message, returning the signature.  Note that $meesage cannot exceed


### PR DESCRIPTION
Sample test that fails on the original but works with the patch.  Also tested on XML::Sig with this patch and DSA 1024 and DSA 2048 but keys work

```

use Test::More tests => 1;
use Crypt::OpenSSL::DSA;
use MIME::Base64;
my $dsa = Crypt::OpenSSL::DSA->generate_parameters( 2048 );
$dsa->generate_key;

isa_ok($dsa, 'Crypt::OpenSSL::DSA');
$p = $dsa->get_p;

print encode_base64($p),"\n";
$q = $dsa->get_q;
print encode_base64($q),"\n";

$g = $dsa->get_g;
print encode_base64($g),"\n";

$y = encode_base64( $dsa->get_pub_key(), '' );
print $y, "\n";


```